### PR TITLE
changed pefile version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Flask-WTF==0.10.1
 itsdangerous==0.24
 Jinja2==2.7.3
 MarkupSafe==0.23
-pefile==1.2.10.post114
+pefile==1.2.10-114
 pluginbase==0.3
 pycparser==2.10
 pygeoip==0.3.1


### PR DESCRIPTION
This caused an installation error because the available versions of pypi did not include `pefile==1.2.10.post114` (`pefile==1.2.10-114` is the correct one).