### PR TITLE
Swapped back printable with decoded functions on string plugin

### DIFF
--- a/aleph/plugins/strings.py
+++ b/aleph/plugins/strings.py
@@ -36,9 +36,9 @@ class StringsPlugin(PluginBase):
         with open(self.sample.path) as f:
 
             if self.options['mode'] == 'printable':
-                string_list = self.extract_strings_decoded(f.read())
-            else:
                 string_list = self.extract_strings_printable(f.read())
+            else:
+                string_list = self.extract_strings_decoded(f.read())
 
             # Convert CSV values on config to list
             if isinstance(self.options['decoder_codecs'], basestring):


### PR DESCRIPTION
I had an if mode == 'printable' leading to the decoder extractor function instead of the printable chars one. My bad =/